### PR TITLE
Update loop.php

### DIFF
--- a/modules/loop-builder/documents/loop.php
+++ b/modules/loop-builder/documents/loop.php
@@ -77,6 +77,7 @@ class Loop extends Theme_Document {
 		$properties = parent::get_properties();
 
 		$properties['support_conditions'] = false;
+		$properties['condition_type'] = 'general';
 
 		return $properties;
 	}


### PR DESCRIPTION
This commit solves an issue with Loop Items and theme builder that makes it stop working with an error.

Steps to reproduce the issue:
- Open Theme Builder
- Create a Loop Item
- Exit and enter Theme builder again

How the error looks like:
![Screenshot 2024-08-30 134626](https://github.com/user-attachments/assets/5a528cf2-f508-4349-b99e-5c62a9e735bf)

Attaching the response to /wp-json/elementor/v1/site-editor/templates, which gets called by theme builder [templates.txt](https://github.com/user-attachments/files/16816390/templates.txt)

Final note: WP_DEBUG was set to false